### PR TITLE
Implement firstrun (resolves #3)

### DIFF
--- a/WF_Proton_Launcher/Main.cpp
+++ b/WF_Proton_Launcher/Main.cpp
@@ -668,7 +668,7 @@ public:
 	{
 		if (fs::is_regular_file(orig))
 		{
-			fs::rename(orig, changed);
+			rename(orig.generic_string().c_str(), changed.generic_string().c_str());
 			mRenamed = true;
 		}
 	}
@@ -679,7 +679,7 @@ public:
 			if (fs::is_regular_file(mOrigPath))
 				fs::remove(mOrigPath);
 
-			fs::rename(mChangedPath, mOrigPath);
+			rename(mChangedPath.generic_string().c_str(), mOrigPath.generic_string().c_str());
 		}
 	}
 

--- a/WF_Proton_Launcher/Main.cpp
+++ b/WF_Proton_Launcher/Main.cpp
@@ -187,7 +187,8 @@ int main(int argc, char** argv)
 		std::cout << "Adding XAudio2_7 registry override." << std::endl;
 		launch("REG ADD HKCU\\Software\\Wine\\DllOverrides /v xaudio2_7 /t REG_SZ /d native /f");
 
-		std::uintmax_t n = fs::remove_all("C:\\dx9temp");
+		fs::remove_all("C:\\dx9temp");
+		fs::remove("directx_Jun2010_redist.exe");
 		std::wcout << " Done." << std::endl;
 
 	}

--- a/WF_Proton_Launcher/Main.cpp
+++ b/WF_Proton_Launcher/Main.cpp
@@ -2,6 +2,7 @@
 #include "Hashlist.hpp"
 #include "MD5.hpp"
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 #include <cassert>
 
@@ -158,11 +159,12 @@ int main(int argc, char** argv)
 		if (!fp)
 		{
 			std::wcout << "Failed to create file on disk." << std::endl;
+			return 1;
 		}
 		CURL *curl = curl_easy_init();
 
 		FileWrapper wrap{ fp, {} };
-		curl_easy_setopt(curl, CURLOPT_URL, ("https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe"));
+		curl_easy_setopt(curl, CURLOPT_URL, "https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe");
 		curl_easy_setopt(curl, CURLOPT_USERAGENT, "Mozilla/5.0 (Warframe_on_Proton)");
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &wrap);
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeFile);
@@ -184,6 +186,8 @@ int main(int argc, char** argv)
 
 		std::cout << "Adding XAudio2_7 registry override." << std::endl;
 		launch("REG ADD HKCU\\Software\\Wine\\DllOverrides /v xaudio2_7 /t REG_SZ /d native /f");
+
+		std::uintmax_t n = fs::remove_all("C:\\dx9temp");
 		std::wcout << " Done." << std::endl;
 
 	}


### PR DESCRIPTION
Currently does the same thing mine does
-installs direct x
-adds xaudio2_7 override

I didn't go the winetricks route for a few reasons 
1. winetricks method doesn't install 64 bit dlls (this is due to the current xaudio2_7 64 bit bug)
2. this option will be unnecessary once proton finishes implementing faudio which includes wma conversion via ffmpeg. 
3. proton overrides dx11 and dxgi dlls anyway for dxvk
4. dx9 mode requires full dx9 to be installed, and so does the official launcher if they ever fix it.


This also does not handle wininet patching, as this is something that valve needs to patch in proton, which gets reset upon remaking the prefix. If we do decide to add this, we need a way to detect the current path for proton.